### PR TITLE
Use tput instead of hardcoded ANSI codes for better portability

### DIFF
--- a/.bashrc.d/man
+++ b/.bashrc.d/man
@@ -1,11 +1,10 @@
-# Source - http://askubuntu.com/questions/35689/highlight-manpages-syntax
-
 # Less Colors for Man Pages
-export LESS_TERMCAP_mb=$'\E[01;31m'       # begin blinking
-export LESS_TERMCAP_md=$'\E[01;38;5;74m'  # begin bold
-export LESS_TERMCAP_me=$'\E[0m'           # end mode
-export LESS_TERMCAP_se=$'\E[0m'           # end standout-mode
-export LESS_TERMCAP_so=$'\E[38;5;246m'    # begin standout-mode - info box
-export LESS_TERMCAP_ue=$'\E[0m'           # end underline
-export LESS_TERMCAP_us=$'\E[04;38;5;146m' # begin underline
+export LESS_TERMCAP_mb=$(tput blink)     # begin blinking
+export LESS_TERMCAP_md=$(tput bold)      # begin bold
+export LESS_TERMCAP_mr=$(tput rev)       # begin reverse
+export LESS_TERMCAP_me=$(tput sgr0)      # end all modes
+export LESS_TERMCAP_se=$(tput rmso)      # end standout
+export LESS_TERMCAP_so=$(tput smso)      # begin standout
+export LESS_TERMCAP_ue=$(tput rmul)      # end underline
+export LESS_TERMCAP_us=$(tput smul)      # begin underline
 

--- a/.bashrc.d/prompt
+++ b/.bashrc.d/prompt
@@ -1,11 +1,11 @@
 # Environment variables to set prompt format and color
-export COLOR_BOLD="\[\e[1m\]"
-export COLOR_DEFAULT="\[\e[0m\]"
-export COLOR_WHITE="\[\033[m\]"
-export COLOR_GREEN="\[\033[32m\]"
-export COLOR_YELLOW="\[\033[33;1m\]"
-export COLOR_RED="\[\e[31m\]"
-export COLOR_BLUE="\[\033[36m\]"
+export COLOR_BOLD="\[$(tput bold)\]"
+export COLOR_DEFAULT="\[$(tput sgr0)\]"
+export COLOR_WHITE="\[$(tput setaf 7)\]"
+export COLOR_GREEN="\[$(tput setaf 2)\]"
+export COLOR_YELLOW="\[$(tput setaf 3)\]"
+export COLOR_RED="\[$(tput setaf 1)\]"
+export COLOR_CYAN="\[$(tput setaf 6)\]"
 
 
 # get current branch in git repo
@@ -63,13 +63,13 @@ prompt_cmd () {
     then
         PS1+="$COLOR_RED"
     else
-        PS1+="$COLOR_BLUE"
+        PS1+="$COLOR_CYAN"
     fi
     PS1+="\u"
     PS1+="$COLOR_WHITE@"
     PS1+="$COLOR_GREEN\h"
     PS1+="$COLOR_WHITE:"
-    PS1+="$COLOR_YELLOW\W"
+    PS1+="$COLOR_BOLD$COLOR_YELLOW\W"
     # Add git branch and status if applicable
     if type parse_git_branch > /dev/null 2>&1; then
         PS1+=$(parse_git_branch)
@@ -81,7 +81,7 @@ prompt_cmd () {
         PS1+="$COLOR_RED"
     fi
     PS1+='\$ '
-    PS1+="$COLOR_WHITE"
+    PS1+="$COLOR_DEFAULT"
     export PROMPT=$PS1
 }
 


### PR DESCRIPTION
A 2nd attempt at PR #2:

> Hardcoded ANSI codes weren't interpreted correctly by Terminal and made some man/less output less readable. e.g.
> `$ echo $'\E[38;5;246m' test`
> 
> A more portable way would be to use tput, which this PR changes. e.g.
> `$ echo $(tput rev) test`

This PR now escapes `\[ \]` the prompt control sequences allowing line wrapping to work properly. Also, the control sequence `\033[33;1m` is correctly translated as `$(tput setaf 3)$(tput bold)` producing the expected yellow color.
